### PR TITLE
Additional tests and Function rename.

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -2,13 +2,6 @@ use std::num::ParseIntError;
 
 #[derive(Debug, PartialEq, PartialOrd)]
 pub enum TokenType {
-    LeftParen,    // x
-    RightParen,   // x
-    LeftBrace,    // x
-    RightBrace,   // x
-    RightBracket, // x
-    LeftBracket,  // x
-
     Comma,
     Dot,
     DotDot,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -89,14 +89,16 @@ impl Scanner {
     fn scan_token(&mut self) {
         if let Some(c) = self.next_char() {
             match c {
-                '(' => self.add_token(TokenType::LeftParen),
-                ')' => self.add_token(TokenType::RightParen),
-                '[' => self.add_token(TokenType::LeftBracket),
-                ']' => self.add_token(TokenType::RightBracket),
+                '(' => {
+                    self.parse_subshell_expansion();
+                }
+                // ')' => self.add_token(TokenType::RightParen),
+                // '[' => self.add_token(TokenType::LeftBracket),
+                // ']' => self.add_token(TokenType::RightBracket),
                 '{' => {
                     self.parse_range_expression();
                 }
-                '}' => self.add_token(TokenType::RightBrace),
+                // '}' => self.add_token(TokenType::RightBrace),
                 ',' => self.add_token(TokenType::Comma),
                 '+' => self.add_token(TokenType::Plus),
                 ';' => self.add_token(TokenType::Semicolon),

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use lexer::Scanner;
 use std::io::stdin;
 
 fn main() {
-    println!("Hello, world!");
     loop {
         let mut command = String::new();
         if let Err(e) = std::io::Stdin::read_line(&stdin(), &mut command) {


### PR DESCRIPTION
Add additional tests for variable and subshell expansion. 

Fix a semi confusing method name for more consistent indexing.

Remove some tokens that should be processed as other tokens (like left parentheses should always be a sub-shell expansion)