### PR TITLE
Variable expansion and subshells, add Vec<Arg> for commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod tests;
 
 use std::io::{self, Write};
 
-use parser::CommandGroup;
+use parser::Command;
 
 fn main() {
     // Input REPL loop
@@ -24,7 +24,7 @@ fn main() {
             break;
         }
 
-        let command_group = CommandGroup::parse(input);
-        println!("{command_group:#?}");
+        let command = Command::parse(input);
+        println!("{command:#?}");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod parser;
 #[cfg(test)]
 mod tests;
 
+use libc::{execle, execve, fork};
 use std::io::{self, Write};
 
 use parser::Command;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -21,7 +21,7 @@ pub struct Command {
     pub argv: Vec<Arg>,
     pub pipe_to: Option<PipeTo>,
     pub redirect_to: Vec<FileRedir>,
-    pub and_then: Option<Box<AndThen>>,
+    pub and_then: Option<AndThen>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -35,7 +35,7 @@ pub struct PipeTo {
 #[expect(dead_code)]
 pub struct AndThen {
     pub conditional: bool,
-    pub target: Command,
+    pub target: Box<Command>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -102,7 +102,7 @@ impl<I: Iterator<Item = Token>> Parser<I> {
                     self.tokens.next();
                     if let Some(next_command) = self.parse_command() {
                         and_then = Some(AndThen {
-                            target: next_command,
+                            target: Box::new(next_command),
                             conditional: false,
                         });
                     }
@@ -112,7 +112,7 @@ impl<I: Iterator<Item = Token>> Parser<I> {
                     self.tokens.next();
                     if let Some(next_command) = self.parse_command() {
                         and_then = Some(AndThen {
-                            target: next_command,
+                            target: Box::new(next_command),
                             conditional: true,
                         });
                     }
@@ -139,7 +139,7 @@ impl<I: Iterator<Item = Token>> Parser<I> {
             Some(Command {
                 argv,
                 pipe_to,
-                and_then: and_then.map(|command| Box::new(command)),
+                and_then,
                 redirect_to,
             })
         } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,28 @@
-use std::iter::Peekable;
 use std::path::PathBuf;
+use std::{hint::unreachable_unchecked, iter::Peekable};
 
 use crate::lexer::{Lexer, Token};
+
+#[derive(Debug)]
+pub enum ParseError {
+    Empty,
+    MissingFileName,
+    UnmatchedDelimiterError,
+    InvalidVariable,
+    UnterminatedStringLiteral,
+    NotFound,
+}
+
+#[derive(Debug)]
+pub struct ParseErrors {
+    errors: Vec<ParseError>,
+}
+
+impl ParseErrors {
+    fn into_iter(self) -> impl Iterator<Item = ParseError> {
+        self.errors.into_iter()
+    }
+}
 
 #[derive(Debug, PartialEq)]
 pub enum Arg {
@@ -11,12 +32,11 @@ pub enum Arg {
 }
 
 #[derive(Debug)]
-pub struct Parser<I: Iterator<Item = Token>> {
+pub struct Parser<I: Iterator<Item = Result<Token, ParseError>>> {
     tokens: Peekable<I>,
 }
 
 #[derive(Debug, PartialEq)]
-#[expect(dead_code)]
 pub struct Command {
     pub argv: Vec<Arg>,
     pub pipe_to: Option<PipeTo>,
@@ -25,14 +45,12 @@ pub struct Command {
 }
 
 #[derive(Debug, PartialEq)]
-#[expect(dead_code)]
 pub struct PipeTo {
     pub pipe_type: RedirType,
     pub target: Box<Command>,
 }
 
 #[derive(Debug, PartialEq)]
-#[expect(dead_code)]
 pub struct AndThen {
     pub conditional: bool,
     pub target: Box<Command>,
@@ -46,19 +64,19 @@ pub enum RedirType {
 }
 
 #[derive(Debug, PartialEq)]
-#[expect(dead_code)]
 pub struct FileRedir {
     pub redirect_type: RedirType,
     pub target: PathBuf,
 }
 
-impl<I: Iterator<Item = Token>> Parser<I> {
+impl<I: Iterator<Item = Result<Token, ParseError>>> Parser<I> {
     pub fn new(tokens: I) -> Self {
         Parser {
             tokens: tokens.peekable(),
         }
     }
-    fn parse_command(&mut self) -> Option<Command> {
+    fn parse_command(&mut self) -> Result<Command, ParseErrors> {
+        let mut errors = Vec::new();
         let mut argv = Vec::new();
         let mut pipe_to = None;
         let mut redirect_to = Vec::new();
@@ -66,99 +84,122 @@ impl<I: Iterator<Item = Token>> Parser<I> {
 
         while let Some(token) = self.tokens.peek() {
             match token {
-                Token::Word(_) => {
-                    if let Some(Token::Word(word)) = self.tokens.next() {
-                        argv.push(Arg::Word(word));
-                    }
-                }
-                Token::RedirOut | Token::RedirErr | Token::RedirBoth => {
-                    let redir_type = self.parse_redir_type()?;
-                    if let Some(Token::Word(path)) = self.tokens.next() {
-                        redirect_to.push(FileRedir {
-                            redirect_type: redir_type,
-                            target: PathBuf::from(path),
-                        });
-                    } else {
-                        eprintln!("Error: Missing filename after redirection");
-                        return None;
-                    }
-                }
-                Token::Pipe | Token::PipeBoth => {
-                    let pipe_token = self.tokens.next();
-                    let pipe_type = match pipe_token {
-                        Some(Token::Pipe) => RedirType::Stdout,
-                        Some(Token::PipeBoth) => RedirType::Both,
-                        _ => RedirType::Stdout,
-                    };
-                    if let Some(next_command) = self.parse_command() {
-                        pipe_to = Some(PipeTo {
-                            pipe_type,
-                            target: Box::new(next_command),
-                        });
-                    }
-                    break;
-                }
-                Token::AndThen => {
-                    self.tokens.next();
-                    if let Some(next_command) = self.parse_command() {
-                        and_then = Some(AndThen {
-                            target: Box::new(next_command),
-                            conditional: false,
-                        });
-                    }
-                    break;
-                }
-                Token::AndThenIf => {
-                    self.tokens.next();
-                    if let Some(next_command) = self.parse_command() {
-                        and_then = Some(AndThen {
-                            target: Box::new(next_command),
-                            conditional: true,
-                        });
-                    }
-                    break;
-                }
-                Token::SubShell(command) => {
-                    if let Some(command) = Command::parse(command) {
-                        argv.push(Arg::Subshell(command));
-                    }
-                    self.tokens.next();
-                }
-                Token::Variable(_) => {
-                    argv.push(Arg::Variable({
-                        match self.tokens.next().unwrap() {
-                            Token::Variable(v) => v,
-                            _ => panic!("what"),
+                Ok(tok) => match tok {
+                    Token::Word(_) => match self.tokens.next() {
+                        Some(Ok(Token::Word(word))) => argv.push(Arg::Word(word)),
+                        Some(Err(e)) => errors.push(e),
+                        _ => unsafe { unreachable_unchecked() },
+                    },
+                    Token::RedirOut | Token::RedirErr | Token::RedirBoth => {
+                        let redir_type = self.parse_redir_type();
+                        if let Some(Ok(Token::Word(path))) = self.tokens.next() {
+                            redirect_to.push(FileRedir {
+                                redirect_type: redir_type,
+                                target: PathBuf::from(path),
+                            });
+                        } else {
+                            errors.push(ParseError::MissingFileName);
                         }
-                    }));
+                    }
+                    Token::Pipe | Token::PipeBoth => {
+                        let pipe_token = self.tokens.next();
+                        let pipe_type = match pipe_token {
+                            Some(Ok(Token::Pipe)) => RedirType::Stdout,
+                            Some(Ok(Token::PipeBoth)) => RedirType::Both,
+                            _ => RedirType::Stdout,
+                        };
+                        match self.parse_command() {
+                            Ok(next_command) => {
+                                pipe_to = Some(PipeTo {
+                                    pipe_type,
+                                    target: Box::new(next_command),
+                                });
+                            }
+                            Err(errs) => {
+                                errors.extend(errs.into_iter());
+                            }
+                        }
+                        break;
+                    }
+                    Token::AndThen => {
+                        self.tokens.next();
+                        match self.parse_command() {
+                            Ok(next_command) => {
+                                and_then = Some(AndThen {
+                                    target: Box::new(next_command),
+                                    conditional: false,
+                                });
+                            }
+                            Err(errs) => {
+                                errors.extend(errs.into_iter());
+                            }
+                        }
+                        break;
+                    }
+                    Token::AndThenIf => {
+                        self.tokens.next();
+                        match self.parse_command() {
+                            Ok(next_command) => {
+                                and_then = Some(AndThen {
+                                    target: Box::new(next_command),
+                                    conditional: true,
+                                });
+                            }
+                            Err(errs) => {
+                                errors.extend(errs.into_iter());
+                            }
+                        }
+                        break;
+                    }
+                    Token::SubShell(command) => {
+                        match Command::parse(command) {
+                            Ok(command) => argv.push(Arg::Subshell(command)),
+                            Err(errs) => errors.extend(errs.into_iter()),
+                        }
+                        self.tokens.next();
+                    }
+                    Token::Variable(s) => {
+                        argv.push(Arg::Variable({
+                            match self.tokens.next().unwrap() {
+                                Ok(Token::Variable(v)) => v,
+                                _ => unsafe { unreachable_unchecked() },
+                            }
+                        }));
+                    }
+                },
+                Err(_) => {
+                    errors.push(match self.tokens.next() {
+                        Some(Err(e)) => e,
+                        _ => panic!("what"),
+                    });
                 }
             }
         }
 
-        if !argv.is_empty() {
-            Some(Command {
+        if !errors.is_empty() || argv.is_empty() {
+            Err(ParseErrors { errors })
+        } else {
+            Ok(Command {
                 argv,
                 pipe_to,
                 and_then,
                 redirect_to,
             })
-        } else {
-            None
         }
     }
 
-    fn parse_redir_type(&mut self) -> Option<RedirType> {
-        match self.tokens.next()? {
-            Token::RedirOut => Some(RedirType::Stdout),
-            Token::RedirErr => Some(RedirType::Stderr),
-            Token::RedirBoth => Some(RedirType::Both),
-            _ => None,
+    fn parse_redir_type(&mut self) -> RedirType {
+        match self.tokens.next() {
+            Some(Ok(Token::RedirOut)) => RedirType::Stdout,
+            Some(Ok(Token::RedirErr)) => RedirType::Stderr,
+            Some(Ok(Token::RedirBoth)) => RedirType::Both,
+            _ => panic!("peek is Token::Redir, but matched none of Redir Variants"),
         }
     }
 }
 
 impl Command {
-    pub fn parse(input: impl AsRef<str>) -> Option<Self> {
+    pub fn parse(input: impl AsRef<str>) -> Result<Self, ParseErrors> {
         let lexer = Lexer::new(input.as_ref());
         let mut parser = Parser::new(lexer);
         parser.parse_command()

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,375 +1,600 @@
-// Disclaimer: This test suite was written by an LLM
+// HACK: This test suite was written by an LLM
+
 #[cfg(test)]
 mod tests {
-    use crate::parser::{CommandGroup, RedirType};
-
     use std::path::PathBuf;
 
-    fn assert_single_command(group: &CommandGroup, expected_args: &[&str]) {
-        assert_eq!(group.commands.len(), 1, "Expected exactly one command");
+    use super::*;
+    use crate::lexer::*;
+    use crate::parser::*;
+
+    fn parse_command(input: &str) -> Option<Command> {
+        Command::parse(input)
+    }
+
+    #[test]
+    fn test_word_parsing() {
+        let input = "echo hello";
+        let command = parse_command(input).expect("Failed to parse command");
+
         assert_eq!(
-            group.commands[0].argv,
-            expected_args.iter().map(|&s| s.to_string()).collect::<Vec<_>>()
+            command.argv,
+            vec![
+                Arg::Word("echo".to_string()),
+                Arg::Word("hello".to_string())
+            ]
         );
     }
 
-    fn assert_pipe_chain(group: &CommandGroup, commands: &[&[&str]]) {
-        let mut current = &group.commands[0];
-        for (i, expected_args) in commands.iter().enumerate() {
-            assert_eq!(
-                current.argv,
-                expected_args.iter().map(|&s| s.to_string()).collect::<Vec<_>>(),
-                "Mismatch in command {} of pipe chain", i
-            );
-            
-            if i < commands.len() - 1 {
-                let pipe_to = current.pipe_to.as_ref().expect("Expected pipe to next command");
-                current = &pipe_to.target;
-            } else {
-                assert!(current.pipe_to.is_none(), "Unexpected pipe at end of chain");
-            }
-        }
+    #[test]
+    fn test_subshell_parsing() {
+        let input = "echo $(ls -l)";
+        let command = parse_command(input).expect("Failed to parse command");
+
+        assert_eq!(
+            command.argv,
+            vec![
+                Arg::Word("echo".to_string()),
+                Arg::Subshell(Command {
+                    argv: vec![Arg::Word("ls".to_string()), Arg::Word("-l".to_string())],
+                    pipe_to: None,
+                    redirect_to: Vec::new(),
+                    and_then: None,
+                })
+            ]
+        );
     }
 
     #[test]
-    fn test_basic_command() {
-        let group = CommandGroup::parse("ls -la");
-        assert_single_command(&group, &["ls", "-la"]);
+    fn test_variable_parsing() {
+        let input = "echo $HOME";
+        let command = parse_command(input).expect("Failed to parse command");
+
+        assert_eq!(
+            command.argv,
+            vec![
+                Arg::Word("echo".to_string()),
+                Arg::Variable("HOME".to_string())
+            ]
+        );
     }
 
     #[test]
-    fn test_command_with_numbers() {
-        let group = CommandGroup::parse("echo 123 456");
-        assert_single_command(&group, &["echo", "123", "456"]);
+    fn test_redirection_stdout() {
+        let input = "echo hello > output.txt";
+        let command = parse_command(input).expect("Failed to parse command");
+
+        assert_eq!(
+            command.argv,
+            vec![
+                Arg::Word("echo".to_string()),
+                Arg::Word("hello".to_string())
+            ]
+        );
+
+        assert_eq!(
+            command.redirect_to,
+            vec![FileRedir {
+                redirect_type: RedirType::Stdout,
+                target: PathBuf::from("output.txt")
+            }]
+        );
     }
 
     #[test]
-    fn test_quoted_arguments() {
-        let tests = vec![
-            ("echo 'hello world'", vec!["echo", "hello world"]),
-            ("echo \"hello world\"", vec!["echo", "hello world"]),
-            ("echo 'hello\"world'", vec!["echo", "hello\"world"]),
-            ("echo \"hello'world\"", vec!["echo", "hello'world"]),
-            ("echo 'hello\\world'", vec!["echo", "hello\\world"]),
-        ];
+    fn test_redirection_stderr() {
+        let input = "echo hello 2> error.txt";
+        let command = parse_command(input).expect("Failed to parse command");
 
-        for (input, expected) in tests {
-            let group = CommandGroup::parse(input);
-            assert_single_command(&group, &expected);
-        }
+        assert_eq!(
+            command.argv,
+            vec![
+                Arg::Word("echo".to_string()),
+                Arg::Word("hello".to_string())
+            ]
+        );
+
+        assert_eq!(
+            command.redirect_to,
+            vec![FileRedir {
+                redirect_type: RedirType::Stderr,
+                target: PathBuf::from("error.txt")
+            }]
+        );
     }
 
     #[test]
-    fn test_mixed_quotes() {
-        let group = CommandGroup::parse("echo 'single' \"double\" normal 'mixed\"quotes'");
-        assert_single_command(&group, &["echo", "single", "double", "normal", "mixed\"quotes"]);
+    fn test_redirection_both() {
+        let input = "echo hello &> output.txt";
+        let command = parse_command(input).expect("Failed to parse command");
+
+        assert_eq!(
+            command.argv,
+            vec![
+                Arg::Word("echo".to_string()),
+                Arg::Word("hello".to_string())
+            ]
+        );
+
+        assert_eq!(
+            command.redirect_to,
+            vec![FileRedir {
+                redirect_type: RedirType::Both,
+                target: PathBuf::from("output.txt")
+            }]
+        );
     }
 
     #[test]
-    fn test_simple_pipe() {
-        let group = CommandGroup::parse("ls -l | grep foo");
-        assert_pipe_chain(&group, &[&["ls", "-l"], &["grep", "foo"]]);
-    }
+    fn test_pipe() {
+        let input = "echo hello | grep world";
+        let command = parse_command(input).expect("Failed to parse command");
 
-    #[test]
-    fn test_multiple_pipes() {
-        let group = CommandGroup::parse("cat file.txt | grep error | wc -l");
-        assert_pipe_chain(&group, &[&["cat", "file.txt"], &["grep", "error"], &["wc", "-l"]]);
+        assert_eq!(
+            command.argv,
+            vec![
+                Arg::Word("echo".to_string()),
+                Arg::Word("hello".to_string())
+            ]
+        );
+
+        assert_eq!(
+            command.pipe_to,
+            Some(PipeTo {
+                pipe_type: RedirType::Stdout,
+                target: Box::new(Command {
+                    argv: vec![
+                        Arg::Word("grep".to_string()),
+                        Arg::Word("world".to_string())
+                    ],
+                    pipe_to: None,
+                    redirect_to: Vec::new(),
+                    and_then: None,
+                })
+            })
+        );
     }
 
     #[test]
     fn test_pipe_both() {
-        let group = CommandGroup::parse("cmd1 |& cmd2");
-        let pipe_to = group.commands[0].pipe_to.as_ref().unwrap();
-        assert!(matches!(pipe_to.pipe_type, RedirType::Both));
-    }
+        let input = "echo hello |& grep world";
+        let command = parse_command(input).expect("Failed to parse command");
 
-    #[test]
-    fn test_stdout_redirection() {
-        let tests = vec![
-            "echo hello > output.txt",
-            "echo hello 1> output.txt",
-            "echo hello >> output.txt",
-            "echo hello 1>> output.txt",
-        ];
-
-        for input in tests {
-            let group = CommandGroup::parse(input);
-            assert_eq!(group.commands[0].argv, vec!["echo", "hello"]);
-            assert_eq!(group.commands[0].redirect_to.len(), 1);
-            assert!(matches!(
-                group.commands[0].redirect_to[0].redirect_type,
-                RedirType::Stdout
-            ));
-            assert_eq!(
-                group.commands[0].redirect_to[0].target,
-                PathBuf::from("output.txt")
-            );
-        }
-    }
-
-    #[test]
-    fn test_stderr_redirection() {
-        let tests = vec![
-            "cmd 2> error.log",
-            "cmd 2>> error.log",
-        ];
-
-        for input in tests {
-            let group = CommandGroup::parse(input);
-            assert_eq!(group.commands[0].argv, vec!["cmd"]);
-            assert_eq!(group.commands[0].redirect_to.len(), 1);
-            assert!(matches!(
-                group.commands[0].redirect_to[0].redirect_type,
-                RedirType::Stderr
-            ));
-            assert_eq!(
-                group.commands[0].redirect_to[0].target,
-                PathBuf::from("error.log")
-            );
-        }
-    }
-
-    #[test]
-    fn test_both_redirection() {
-        let tests = vec!["cmd &> both.log", "cmd &>> both.log"];
-
-        for input in tests {
-            let group = CommandGroup::parse(input);
-            assert_eq!(group.commands[0].argv, vec!["cmd"]);
-            assert_eq!(group.commands[0].redirect_to.len(), 1);
-            assert!(matches!(
-                group.commands[0].redirect_to[0].redirect_type,
-                RedirType::Both
-            ));
-            assert_eq!(
-                group.commands[0].redirect_to[0].target,
-                PathBuf::from("both.log")
-            );
-        }
-    }
-
-    #[test]
-    fn test_multiple_redirections() {
-        let group = CommandGroup::parse("cmd > stdout.log 2> stderr.log");
-        assert_eq!(group.commands[0].argv, vec!["cmd"]);
-        assert_eq!(group.commands[0].redirect_to.len(), 2);
-        
-        assert!(matches!(
-            group.commands[0].redirect_to[0].redirect_type,
-            RedirType::Stdout
-        ));
         assert_eq!(
-            group.commands[0].redirect_to[0].target,
-            PathBuf::from("stdout.log")
+            command.argv,
+            vec![
+                Arg::Word("echo".to_string()),
+                Arg::Word("hello".to_string())
+            ]
         );
-        
-        assert!(matches!(
-            group.commands[0].redirect_to[1].redirect_type,
-            RedirType::Stderr
-        ));
+
         assert_eq!(
-            group.commands[0].redirect_to[1].target,
-            PathBuf::from("stderr.log")
+            command.pipe_to,
+            Some(PipeTo {
+                pipe_type: RedirType::Both,
+                target: Box::new(Command {
+                    argv: vec![
+                        Arg::Word("grep".to_string()),
+                        Arg::Word("world".to_string())
+                    ],
+                    pipe_to: None,
+                    redirect_to: Vec::new(),
+                    and_then: None,
+                })
+            })
         );
     }
 
     #[test]
-    fn test_complex_commands() {
-        let complex_tests = vec![
-            (
-                "find . -name '*.rs' | xargs grep 'fn main' > output.txt 2> error.log",
-                vec![
-                    vec!["find", ".", "-name", "*.rs"],
-                    vec!["xargs", "grep", "fn main"],
-                ],
-            ),
-            (
-                "cat file.txt | grep -v error |& wc -l > count.txt",
-                vec![
-                    vec!["cat", "file.txt"],
-                    vec!["grep", "-v", "error"],
-                    vec!["wc", "-l"],
-                ],
-            ),
-            (
-                "echo 'Hello, world!' > greeting.txt | cat greeting.txt | tr '[:lower:]' '[:upper:]'",
-                vec![
-                    vec!["echo", "Hello, world!"],
-                    vec!["cat", "greeting.txt"],
-                    vec!["tr", "[:lower:]", "[:upper:]"],
-                ],
-            ),
-        ];
+    fn test_and_then_if() {
+        let input = "echo hello && echo world";
+        let command = parse_command(input).expect("Failed to parse command");
 
-        for (input, expected_commands) in complex_tests {
-            let group = CommandGroup::parse(input);
-            assert_pipe_chain(&group, &expected_commands.iter().map(|v| v.as_slice()).collect::<Vec<_>>());
-        }
+        assert_eq!(
+            command.argv,
+            vec![
+                Arg::Word("echo".to_string()),
+                Arg::Word("hello".to_string())
+            ]
+        );
+
+        assert_eq!(
+            command.and_then,
+            Some(Box::new(AndThen {
+                target: Command {
+                    argv: vec![
+                        Arg::Word("echo".to_string()),
+                        Arg::Word("world".to_string())
+                    ],
+                    pipe_to: None,
+                    redirect_to: Vec::new(),
+                    and_then: None,
+                },
+                conditional: true
+            }))
+        );
+    }
+
+    #[test]
+    fn test_and_then() {
+        let input = "echo hello ; echo world";
+        let command = parse_command(input).expect("Failed to parse command");
+
+        assert_eq!(
+            command.argv,
+            vec![
+                Arg::Word("echo".to_string()),
+                Arg::Word("hello".to_string())
+            ]
+        );
+
+        assert_eq!(
+            command.and_then,
+            Some(Box::new(AndThen {
+                target: Command {
+                    argv: vec![
+                        Arg::Word("echo".to_string()),
+                        Arg::Word("world".to_string())
+                    ],
+                    pipe_to: None,
+                    redirect_to: Vec::new(),
+                    and_then: None,
+                },
+                conditional: false
+            }))
+        );
     }
 
     #[test]
     fn test_empty_input() {
-        let group = CommandGroup::parse("");
-        assert!(group.commands.is_empty());
-        
-        let group = CommandGroup::parse("   ");
-        assert!(group.commands.is_empty());
+        let input = "";
+        let command = parse_command(input);
+        assert_eq!(command, None);
     }
 
     #[test]
-    fn test_invalid_redirections() {
-        let tests = vec![
-            "cmd >",           // Missing filename
-            "cmd 2>",          // Missing filename
-            "cmd &>",          // Missing filename
-            "cmd > > file",    // Double redirection
-            "cmd 2> > file",   // Invalid redirection syntax
-        ];
-
-        for input in tests {
-            let group = CommandGroup::parse(input);
-            assert!(group.commands.is_empty(), "Expected empty command group for invalid input: {}", input);
-        }
+    fn test_unclosed_subshell() {
+        let input = "echo $(ls -l";
+        let command = parse_command(input);
+        assert_eq!(command, None);
     }
 
     #[test]
-    fn test_whitespace_handling() {
-        let tests = vec![
-            "cmd   arg1    arg2",
-            "\tcmd\targ1\targ2",
-            "cmd \t arg1 \t arg2",
-            "  cmd  arg1  arg2  ",
-        ];
+    fn test_multiple_redirections() {
+        let input = "echo hello > out.txt 2> err.txt";
+        let command = parse_command(input).expect("Failed to parse command");
 
-        for input in tests {
-            let group = CommandGroup::parse(input);
-            assert_single_command(&group, &["cmd", "arg1", "arg2"]);
-        }
-    }
-
-    #[test]
-    fn test_sequential_commands() {
-        let group = CommandGroup::parse("echo hello ; echo world");
-        assert_eq!(group.commands[0].argv, vec!["echo", "hello"]);
-
-        let and_then = group.commands[0]
-            .and_then
-            .as_ref()
-            .expect("Expected AndThen");
-        assert!(!and_then.conditional, "Expected non-conditional AndThen");
-        assert_eq!(and_then.target.commands[0].argv, vec!["echo", "world"]);
-    }
-
-    #[test]
-    fn test_conditional_commands() {
-        let group = CommandGroup::parse("test -f file.txt && echo 'file exists'");
-        assert_eq!(group.commands[0].argv, vec!["test", "-f", "file.txt"]);
-
-        let and_then = group.commands[0]
-            .and_then
-            .as_ref()
-            .expect("Expected AndThen");
-        assert!(and_then.conditional, "Expected conditional AndThen");
         assert_eq!(
-            and_then.target.commands[0].argv,
-            vec!["echo", "file exists"]
+            command.argv,
+            vec![
+                Arg::Word("echo".to_string()),
+                Arg::Word("hello".to_string())
+            ]
+        );
+
+        assert_eq!(
+            command.redirect_to,
+            vec![
+                FileRedir {
+                    redirect_type: RedirType::Stdout,
+                    target: PathBuf::from("out.txt")
+                },
+                FileRedir {
+                    redirect_type: RedirType::Stderr,
+                    target: PathBuf::from("err.txt")
+                }
+            ]
         );
     }
 
     #[test]
-    fn test_multiple_sequential_commands() {
-        let group = CommandGroup::parse("cmd1 ; cmd2 ; cmd3");
-        assert_eq!(group.commands[0].argv, vec!["cmd1"]);
+    fn test_edge_case_variable_with_special_chars() {
+        let input = "echo $HOME_VAR";
+        let command = parse_command(input).expect("Failed to parse command");
 
-        let and_then1 = group.commands[0]
-            .and_then
-            .as_ref()
-            .expect("Expected first AndThen");
-        assert!(!and_then1.conditional);
-        assert_eq!(and_then1.target.commands[0].argv, vec!["cmd2"]);
-
-        let and_then2 = and_then1.target.commands[0]
-            .and_then
-            .as_ref()
-            .expect("Expected second AndThen");
-        assert!(!and_then2.conditional);
-        assert_eq!(and_then2.target.commands[0].argv, vec!["cmd3"]);
-    }
-
-    #[test]
-    fn test_multiple_conditional_commands() {
-        let group = CommandGroup::parse("test -d dir && cd dir && echo 'changed dir'");
-        assert_eq!(group.commands[0].argv, vec!["test", "-d", "dir"]);
-
-        let and_then1 = group.commands[0]
-            .and_then
-            .as_ref()
-            .expect("Expected first AndThen");
-        assert!(and_then1.conditional);
-        assert_eq!(and_then1.target.commands[0].argv, vec!["cd", "dir"]);
-
-        let and_then2 = and_then1.target.commands[0]
-            .and_then
-            .as_ref()
-            .expect("Expected second AndThen");
-        assert!(and_then2.conditional);
         assert_eq!(
-            and_then2.target.commands[0].argv,
-            vec!["echo", "changed dir"]
+            command.argv,
+            vec![
+                Arg::Word("echo".to_string()),
+                Arg::Variable("HOME_VAR".to_string())
+            ]
         );
     }
 
     #[test]
-    fn test_mixed_conditional_and_sequential() {
-        let group = CommandGroup::parse("mkdir dir && cd dir ; echo 'done'");
-        assert_eq!(group.commands[0].argv, vec!["mkdir", "dir"]);
-
-        let and_then1 = group.commands[0]
-            .and_then
-            .as_ref()
-            .expect("Expected first AndThen");
-        assert!(and_then1.conditional);
-        assert_eq!(and_then1.target.commands[0].argv, vec!["cd", "dir"]);
-
-        let and_then2 = and_then1.target.commands[0]
-            .and_then
-            .as_ref()
-            .expect("Expected second AndThen");
-        assert!(!and_then2.conditional);
-        assert_eq!(and_then2.target.commands[0].argv, vec!["echo", "done"]);
+    fn test_invalid_variable() {
+        let input = "echo $1invalidVar";
+        let command = parse_command(input);
+        assert_eq!(command, None);
     }
 
     #[test]
-    fn test_and_then_with_redirections() {
-        let group = CommandGroup::parse("echo 'log entry' > log.txt && cat log.txt");
-        assert_eq!(group.commands[0].argv, vec!["echo", "log entry"]);
+    fn test_empty_word() {
+        let input = "echo ";
+        let command = parse_command(input).expect("Failed to parse command");
+
+        assert_eq!(command.argv, vec![Arg::Word("echo".to_string())]);
+        assert!(command.pipe_to.is_none());
+        assert!(command.redirect_to.is_empty());
+    }
+
+    #[test]
+    fn test_multiple_spaces_between_words() {
+        let input = "echo    hello   world";
+        let command = parse_command(input).expect("Failed to parse command");
+
         assert_eq!(
-            group.commands[0].redirect_to[0].target.to_str().unwrap(),
-            "log.txt"
+            command.argv,
+            vec![
+                Arg::Word("echo".to_string()),
+                Arg::Word("hello".to_string()),
+                Arg::Word("world".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_multiple_redirections_same_type() {
+        let input = "echo hello > output.txt > another_output.txt";
+        let command = parse_command(input).expect("Failed to parse command");
+
+        assert_eq!(
+            command.argv,
+            vec![
+                Arg::Word("echo".to_string()),
+                Arg::Word("hello".to_string())
+            ]
         );
 
-        let and_then = group.commands[0]
-            .and_then
-            .as_ref()
-            .expect("Expected AndThen");
-        assert!(and_then.conditional);
-        assert_eq!(and_then.target.commands[0].argv, vec!["cat", "log.txt"]);
+        assert_eq!(
+            command.redirect_to,
+            vec![
+                FileRedir {
+                    redirect_type: RedirType::Stdout,
+                    target: PathBuf::from("output.txt")
+                },
+                FileRedir {
+                    redirect_type: RedirType::Stdout,
+                    target: PathBuf::from("another_output.txt")
+                }
+            ]
+        );
     }
 
     #[test]
-    fn test_and_then_with_pipes() {
-        let group = CommandGroup::parse("cat file.txt | grep error && echo 'found error'");
-        assert_eq!(group.commands[0].argv, vec!["cat", "file.txt"]);
+    fn test_redirection_with_pipe() {
+        let input = "echo hello > output.txt | grep world";
+        let command = parse_command(input).expect("Failed to parse command");
 
-        let pipe_to = group.commands[0].pipe_to.as_ref().expect("Expected pipe");
-        assert_eq!(pipe_to.target.argv, vec!["grep", "error"]);
-
-        let and_then = pipe_to.target.and_then.as_ref().expect("Expected AndThen");
-        assert!(and_then.conditional);
         assert_eq!(
-            and_then.target.commands[0].argv,
-            vec!["echo", "found error"]
+            command.argv,
+            vec![
+                Arg::Word("echo".to_string()),
+                Arg::Word("hello".to_string())
+            ]
+        );
+
+        assert_eq!(
+            command.redirect_to,
+            vec![FileRedir {
+                redirect_type: RedirType::Stdout,
+                target: PathBuf::from("output.txt")
+            }]
+        );
+
+        assert_eq!(
+            command.pipe_to,
+            Some(PipeTo {
+                pipe_type: RedirType::Stdout,
+                target: Box::new(Command {
+                    argv: vec![
+                        Arg::Word("grep".to_string()),
+                        Arg::Word("world".to_string())
+                    ],
+                    pipe_to: None,
+                    redirect_to: Vec::new(),
+                    and_then: None,
+                })
+            })
+        );
+    }
+
+    #[test]
+    fn test_redirection_with_and_then() {
+        let input = "echo hello > output.txt && echo world";
+        let command = parse_command(input).expect("Failed to parse command");
+
+        assert_eq!(
+            command.argv,
+            vec![
+                Arg::Word("echo".to_string()),
+                Arg::Word("hello".to_string())
+            ]
+        );
+
+        assert_eq!(
+            command.redirect_to,
+            vec![FileRedir {
+                redirect_type: RedirType::Stdout,
+                target: PathBuf::from("output.txt")
+            }]
+        );
+
+        assert_eq!(
+            command.and_then,
+            Some(Box::new(AndThen {
+                target: Command {
+                    argv: vec![
+                        Arg::Word("echo".to_string()),
+                        Arg::Word("world".to_string())
+                    ],
+                    pipe_to: None,
+                    redirect_to: Vec::new(),
+                    and_then: None,
+                },
+                conditional: true
+            }))
+        );
+    }
+
+    #[test]
+    fn test_variable_in_subshell() {
+        let input = "echo $(echo $USER)";
+        let command = parse_command(input).expect("Failed to parse command");
+
+        assert_eq!(
+            command.argv,
+            vec![
+                Arg::Word("echo".to_string()),
+                Arg::Subshell(Command {
+                    argv: vec![
+                        Arg::Word("echo".to_string()),
+                        Arg::Variable("USER".to_string())
+                    ],
+                    pipe_to: None,
+                    redirect_to: Vec::new(),
+                    and_then: None,
+                })
+            ]
+        );
+    }
+
+    #[test]
+    fn test_subshell_with_redirection() {
+        let input = "echo $(ls) > output.txt";
+        let command = parse_command(input).expect("Failed to parse command");
+
+        assert_eq!(
+            command.argv,
+            vec![
+                Arg::Word("echo".to_string()),
+                Arg::Subshell(Command {
+                    argv: vec![Arg::Word("ls".to_string())],
+                    pipe_to: None,
+                    redirect_to: Vec::new(),
+                    and_then: None,
+                })
+            ]
+        );
+
+        assert_eq!(
+            command.redirect_to,
+            vec![FileRedir {
+                redirect_type: RedirType::Stdout,
+                target: PathBuf::from("output.txt")
+            }]
+        );
+    }
+
+    #[test]
+    fn test_unclosed_quotes() {
+        let input = "echo \"hello";
+        let command = parse_command(input);
+        assert_eq!(command, None);
+    }
+
+    #[test]
+    fn test_subshell_missing_closing_paren() {
+        let input = "echo $(ls";
+        let command = parse_command(input);
+        assert_eq!(command, None);
+    }
+
+    #[test]
+    fn test_and_then_with_pipe() {
+        let input = "echo hello && echo world | grep test";
+        let command = parse_command(input).expect("Failed to parse command");
+
+        assert_eq!(
+            command.argv,
+            vec![
+                Arg::Word("echo".to_string()),
+                Arg::Word("hello".to_string())
+            ]
+        );
+
+        assert_eq!(
+            command.and_then,
+            Some(Box::new(AndThen {
+                target: Command {
+                    argv: vec![
+                        Arg::Word("echo".to_string()),
+                        Arg::Word("world".to_string())
+                    ],
+                    pipe_to: Some(PipeTo {
+                        pipe_type: RedirType::Stdout,
+                        target: Box::new(Command {
+                            argv: vec![
+                                Arg::Word("grep".to_string()),
+                                Arg::Word("test".to_string())
+                            ],
+                            pipe_to: None,
+                            redirect_to: Vec::new(),
+                            and_then: None,
+                        })
+                    }),
+                    redirect_to: Vec::new(),
+                    and_then: None,
+                },
+                conditional: true
+            }))
+        );
+    }
+
+    #[test]
+    fn test_pipe_with_multiple_commands() {
+        let input = "echo hello | grep world | sort";
+        let command = parse_command(input).expect("Failed to parse command");
+
+        assert_eq!(
+            command.argv,
+            vec![
+                Arg::Word("echo".to_string()),
+                Arg::Word("hello".to_string())
+            ]
+        );
+
+        assert_eq!(
+            command.pipe_to,
+            Some(PipeTo {
+                pipe_type: RedirType::Stdout,
+                target: Box::new(Command {
+                    argv: vec![
+                        Arg::Word("grep".to_string()),
+                        Arg::Word("world".to_string())
+                    ],
+                    pipe_to: Some(PipeTo {
+                        pipe_type: RedirType::Stdout,
+                        target: Box::new(Command {
+                            argv: vec![Arg::Word("sort".to_string())],
+                            pipe_to: None,
+                            redirect_to: Vec::new(),
+                            and_then: None,
+                        })
+                    }),
+                    redirect_to: Vec::new(),
+                    and_then: None,
+                })
+            })
+        );
+    }
+
+    #[test]
+    fn test_empty_subshell() {
+        let input = "echo $(echo)";
+        let command = parse_command(input).expect("Failed to parse command");
+
+        assert_eq!(
+            command.argv,
+            vec![
+                Arg::Word("echo".to_string()),
+                Arg::Subshell(Command {
+                    argv: vec![Arg::Word("echo".to_string())],
+                    pipe_to: None,
+                    redirect_to: Vec::new(),
+                    and_then: None,
+                })
+            ]
         );
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -200,8 +200,8 @@ mod tests {
 
         assert_eq!(
             command.and_then,
-            Some(Box::new(AndThen {
-                target: Command {
+            Some(AndThen {
+                target: Box::new(Command {
                     argv: vec![
                         Arg::Word("echo".to_string()),
                         Arg::Word("world".to_string())
@@ -209,9 +209,9 @@ mod tests {
                     pipe_to: None,
                     redirect_to: Vec::new(),
                     and_then: None,
-                },
+                }),
                 conditional: true
-            }))
+            })
         );
     }
 
@@ -230,8 +230,8 @@ mod tests {
 
         assert_eq!(
             command.and_then,
-            Some(Box::new(AndThen {
-                target: Command {
+            Some(AndThen {
+                target: Box::new(Command {
                     argv: vec![
                         Arg::Word("echo".to_string()),
                         Arg::Word("world".to_string())
@@ -239,9 +239,9 @@ mod tests {
                     pipe_to: None,
                     redirect_to: Vec::new(),
                     and_then: None,
-                },
+                }),
                 conditional: false
-            }))
+            })
         );
     }
 
@@ -422,8 +422,8 @@ mod tests {
 
         assert_eq!(
             command.and_then,
-            Some(Box::new(AndThen {
-                target: Command {
+            Some(AndThen {
+                target: Box::new(Command {
                     argv: vec![
                         Arg::Word("echo".to_string()),
                         Arg::Word("world".to_string())
@@ -431,9 +431,9 @@ mod tests {
                     pipe_to: None,
                     redirect_to: Vec::new(),
                     and_then: None,
-                },
+                }),
                 conditional: true
-            }))
+            })
         );
     }
 
@@ -515,8 +515,8 @@ mod tests {
 
         assert_eq!(
             command.and_then,
-            Some(Box::new(AndThen {
-                target: Command {
+            Some(AndThen {
+                target: Box::new(Command {
                     argv: vec![
                         Arg::Word("echo".to_string()),
                         Arg::Word("world".to_string())
@@ -535,9 +535,9 @@ mod tests {
                     }),
                     redirect_to: Vec::new(),
                     and_then: None,
-                },
+                }),
                 conditional: true
-            }))
+            })
         );
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -9,7 +9,10 @@ mod tests {
     use crate::parser::*;
 
     fn parse_command(input: &str) -> Option<Command> {
-        Command::parse(input)
+        match Command::parse(input) {
+            Ok(s) => Some(s),
+            Err(_) => None,
+        }
     }
 
     #[test]


### PR DESCRIPTION
### Add Support for Subshells + Variable Expansion

- Subshell expansion for `cmd1 (cmd2)` and `cmd1 $(cmd2)`
- Variable expansion for `$name` but not `${name}
- Instead of an `Option<Token>`,  `Lexer::lex_subshell` returns a `Result<Token>` so that unmatched parentheses can be collected as errors to emit
- We could implement this for single and double quotes as well. 
- Because subshell results should get placed directly into the containing command, I changed `Command::argv` from a `Vec<String>` to a `Vec<Arg>` where `Arg` is an enum with variants for basic "words", subshells, and variables. 

### Remove redundant CommandGroup
- Because additional commands are being stored in the `and_then` field of the `Command` struct, the `commands` in `CommandGroup` was redundant. 
- Because of this, `AndThen` now has to have a `Box<Command>`

### Update Tests
- To test all the new functionality, I basically dropped all the previous tests and (per precedent) had a LLM write a bunch of tests that use the new `Vec<Arg>` format for `Command`.
