### PR TITLE
add variable expansion, change safe `fork` return

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ mod tests;
 
 use std::io::{self, Write};
 
-use parser::Command;
+use parser::{Arg, Command};
 
 fn main() {
     // Input REPL
@@ -39,7 +39,17 @@ use crate::safe_wrappers::WaitStatus;
 fn run_command(cmd: &Command) -> io::Result<WaitStatus> {
     match fork() {
         ForkReturn::Child => {
-            let args: Vec<String> = cmd.args()?;
+            let args = cmd
+                .argv
+                .iter()
+                .filter_map(|arg| {
+                    if let Arg::Word(w) = arg {
+                        Some(w)
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
 
             if args.len() == 0 {
                 return Ok(WaitStatus::Exited(0));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,4 @@
 use core::panic;
-use std::io::Result as IOResult;
 use std::path::PathBuf;
 use std::{hint::unreachable_unchecked, iter::Peekable};
 
@@ -221,18 +220,5 @@ impl Command {
         let lexer = Lexer::new(input.as_ref());
         let mut parser = Parser::new(lexer);
         parser.parse_command()
-    }
-
-    pub fn args(&self) -> IOResult<Vec<String>> {
-        use crate::safe_wrappers::getenv;
-        let mut args = Vec::new();
-        for arg in &self.argv {
-            match arg {
-                Arg::Word(w) => args.push(w.clone()),
-                Arg::Variable(var_id) => args.push(getenv(var_id)?),
-                Arg::Subshell(_cmd) => todo!(),
-            }
-        }
-        Ok(args)
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,3 +1,5 @@
+use core::panic;
+use std::io::Result as IOResult;
 use std::path::PathBuf;
 use std::{hint::unreachable_unchecked, iter::Peekable};
 
@@ -219,5 +221,18 @@ impl Command {
         let lexer = Lexer::new(input.as_ref());
         let mut parser = Parser::new(lexer);
         parser.parse_command()
+    }
+
+    pub fn args(&self) -> IOResult<Vec<String>> {
+        use crate::safe_wrappers::getenv;
+        let mut args = Vec::new();
+        for arg in &self.argv {
+            match arg {
+                Arg::Word(w) => args.push(w.clone()),
+                Arg::Variable(var_id) => args.push(getenv(var_id)?),
+                Arg::Subshell(_cmd) => todo!(),
+            }
+        }
+        Ok(args)
     }
 }


### PR DESCRIPTION
- Added a safe wrapper for `getenv` that returns a `io::Result<String>`.
- Changed return type for `fork` from `io::Result<ForkReturn>` to just `ForkReturn`, panicing on a failed `libc::fork`
- Added a convience `Command::args` function that returns `Vec<String>`.
    - I don't really see a way to get around the owned `String` in the return `Vec` unless we take a `&mut self` in `CommandArgs` and replace each non `Word` arg with a owned `Word`. Maybe return a `OsStr` out of the safe `getenv` instead of a `String`?
